### PR TITLE
Add a convenience function to expose any job processing errors easily

### DIFF
--- a/invopop/transform.go
+++ b/invopop/transform.go
@@ -1,6 +1,9 @@
 package invopop
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"fmt"
+)
 
 const (
 	transformBasePath = "/transform/v1"
@@ -24,6 +27,20 @@ type Job struct {
 	// Properties returned in response after completion
 	Envelope    json.RawMessage `json:"envelope,omitempty"`
 	Attachments []*Attachment   `json:"attachments,omitempty"`
+}
+
+// Status returns true if the job has completed, and if there were any problems
+// executing the jobs, an error.
+func (j *Job) Status() (bool, error) {
+	if j.CompletedAt == "" {
+		return false, nil
+	}
+	intent := j.Intents[len(j.Intents)]
+	event := intent.Events[len(intent.Events)]
+	if event.Status == "KO" {
+		return true, fmt.Errorf("Task %s failed at %s: %s", intent.TaskID, event.At, event.Message)
+	}
+	return true, nil
 }
 
 // JobIntent represents an attempt to execute a task.


### PR DESCRIPTION
The motivation for this PR is to for `invocli` to be able to detect easily when a job completed successfully versus with errors.  I could easily put this logic directly in `invocli` if that makes more sense, but maybe it makes sense to include it here, where I guess maybe it can be used more broadly?  WDYT?