### PR TITLE
Add Job.Status field, rename Status() method to Done()

### DIFF
--- a/invopop/transform_jobs.go
+++ b/invopop/transform_jobs.go
@@ -29,6 +29,7 @@ type Job struct {
 	Args map[string]string `json:"args,omitempty" title:"Args" description:"Any additional arguments that might be relevant for processing."`
 	Tags []string          `json:"tags,omitempty" title:"Tags" description:"Any tags that may be useful to be associated with the job."`
 
+	Status      string `json:"status,omitempty" title:"Status" description:"Last known status text for this job (e.g. run, queued, ok, ko, skip, cancel, err)."`
 	CompletedAt string `json:"completed_at,omitempty"`
 
 	Intents []*JobIntent `json:"intents,omitempty"`
@@ -48,9 +49,14 @@ type Fault struct {
 	Fields   string   `json:"fields,omitempty" title:"Fields" description:"Nested validation field errors"` // Deprecated
 }
 
-// Status returns true if the job has completed, and if there were any problems
-// executing the jobs, an error.
-func (j *Job) Status() (bool, error) {
+// Done returns true if the job has completed, and if there were any problems
+// executing the job, an error.
+//
+// Note: this method was previously named Status(); it was renamed in favor of
+// the Status string field on Job, which mirrors the API's job status text.
+// Callers that previously used job.Status() should switch to job.Done() (same
+// behavior) or read job.Status directly for the raw status text.
+func (j *Job) Done() (bool, error) {
 	if j.CompletedAt == "" {
 		return false, nil
 	}


### PR DESCRIPTION
## Summary
- Adds `Status` to the `Job` struct, mirroring the `status` field the transform service already exposes on jobs (values: `run`, `queued`, `ok`, `ko`, `skip`, `cancel`, `err`).
- **Breaking change:** the existing `(j *Job) Status() (bool, error)` method is renamed to `Done()` so the cleaner field name is free. Behavior is unchanged — callers that previously did `job.Status()` should switch to `job.Done()`, or read `job.Status` directly for the raw status text. A migration note is left on the renamed method's doc comment.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [ ] Confirm a fetched job round-trips with the new `status` field populated against a live API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)